### PR TITLE
fix: timetable parsing fixes and postman documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 	- [Running the application](#running-the-application)
 	- [Stopping the application](#stopping-the-application)
 	- [Using management commands of the CLI application](#using-management-commands-of-the-cli-application)
+- [API Documentation](#api-documentation)
 - [Developer](#developer)
 
 
@@ -137,6 +138,12 @@ vitty.bat cli <command>
 ```
 
 > **NOTE:** Replace script file names with `.vitty-local.sh` and `.vitty-local.bat` for local environment
+
+<br>
+<br>
+
+## API Documentation
+Postman API documentation - [Vitty API](https://documenter.getpostman.com/view/23405999/2s93zFWeZx)
 
 <br>
 <br>

--- a/vitty-backend-api/api/v1/timetableHandler.go
+++ b/vitty-backend-api/api/v1/timetableHandler.go
@@ -6,9 +6,17 @@ import (
 )
 
 func getTimetable(c *fiber.Ctx) error {
-	data := c.FormValue("request")
+	response := struct {
+		Data string `json:"data"`
+	}{}
 
-	slots, err := utils.DetectTimetable(data)
+	if err := c.BodyParser(&response); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"detail": err.Error(),
+		})
+	}
+
+	slots, err := utils.DetectTimetable(response.Data)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"detail": err.Error(),
@@ -26,9 +34,17 @@ func getTimetable(c *fiber.Ctx) error {
 }
 
 func getTimetableV2(c *fiber.Ctx) error {
-	data := c.FormValue("request")
+	response := struct {
+		Data string `json:"data"`
+	}{}
 
-	slots, err := utils.DetectTimetableV2(data)
+	if err := c.BodyParser(&response); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"detail": err.Error(),
+		})
+	}
+
+	slots, err := utils.DetectTimetableV2(response.Data)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"detail": err.Error(),
@@ -47,6 +63,6 @@ func getTimetableV2(c *fiber.Ctx) error {
 
 func V1Handler(api fiber.Router) {
 	group := api.Group("/v1")
-	group.Get("/timetable", getTimetable)
-	group.Get("/timetable/v2", getTimetableV2)
+	group.Post("/timetable", getTimetable)
+	group.Post("/timetableV2", getTimetableV2)
 }

--- a/vitty-backend-api/internal/models/timetable.go
+++ b/vitty-backend-api/internal/models/timetable.go
@@ -52,6 +52,10 @@ func (t Timetable) GetDaywiseTimetable() map[string][]Slot {
 				if err != nil {
 					log.Println("Error parsing time: ", err)
 				}
+				slot.EndTime, err = time.Parse("15:04", TheoryTimings[index].EndTime)
+				if err != nil {
+					log.Println("Error parsing time: ", err)
+				}
 				resp[day] = append(resp[day], slot)
 			} else if slices.Contains(value["Lab"], slot.Slot) {
 				resp[day] = append(resp[day], slot)

--- a/vitty-backend-api/internal/utils/timetableDetection.go
+++ b/vitty-backend-api/internal/utils/timetableDetection.go
@@ -56,7 +56,6 @@ func DetectTimetable(text string) ([]TimetableSlotV1, error) {
 
 func DetectTimetableV2(text string) ([]TimetableSlotV1, error) {
 	text = strings.ReplaceAll(text, "\r", "")
-
 	var code, name, venue []string
 	var slots [][]string
 	var Slots []TimetableSlotV1
@@ -64,8 +63,8 @@ func DetectTimetableV2(text string) ([]TimetableSlotV1, error) {
 	re := regexp.MustCompile("[A-Z]{4}[0-9]{3}.+\n|[A-Z]{3}[0-9]{4}.+\n").FindAllString(text, -1)
 
 	for _, c := range re {
-		code_n := regexp.MustCompile("[A-Z]{4}[0-9]{3}|[A-Z]{3}[0-9]{4}").FindAllString(c, -1)[0]
-		name_n := strings.TrimRight(strings.TrimLeft(c, code_n), "\n")
+		code_n := regexp.MustCompile("[A-Z]{4}[0-9]{3}[LPE]|[A-Z]{3}[0-9]{4}[LPE]").FindAllString(c, -1)[0]
+		name_n := strings.TrimRight(strings.TrimLeft(c, code_n)[3:], "\n")
 		if code_n != "" && name_n != "" {
 			code = append(code, code_n)
 			name = append(name, name_n)


### PR DESCRIPTION
# Fixes and Documentation
Checklist - 
- [x] Return class end time correctly while getting user timetable
- [x] Fix naming of courses while parsing timetable
- [x] Change methods and functions for handling v1 endpoints of the API
- [x] Update and publish API documentation of the API using postman